### PR TITLE
Add IgnoreInvalidCookie bool

### DIFF
--- a/Leaf.xNet/~Http/HttpRequest.cs
+++ b/Leaf.xNet/~Http/HttpRequest.cs
@@ -278,6 +278,11 @@ namespace Leaf.xNet
         /// </summary>
         public string AcceptEncoding { get; set; } = "gzip,deflate";
 
+        /// <summary>
+        /// Dont throw exception when received cookie name is invalid, just ignore.
+        /// </summary>
+        public bool IgnoreInvalidCookie { get; set; } = false;
+
         #region Поведение
 
         /// <summary>
@@ -3489,7 +3494,7 @@ namespace Leaf.xNet
             // Cookies isn't set now
             if (Cookies == null)
             {
-                Cookies = new CookieStorage();
+                Cookies = new CookieStorage(ignoreInvalidCookie: IgnoreInvalidCookie);
                 return ToHeadersString(headers);
             }
 

--- a/Leaf.xNet/~Http/HttpResponse.cs
+++ b/Leaf.xNet/~Http/HttpResponse.cs
@@ -836,7 +836,7 @@ namespace Leaf.xNet
             {
                 Cookies = _request.Cookies != null && !_request.Cookies.IsLocked
                     ? _request.Cookies
-                    : new CookieStorage();
+                    : new CookieStorage(ignoreInvalidCookie: _request.IgnoreInvalidCookie);
             }
 
             if (_receiverHelper == null)


### PR DESCRIPTION
If true cookie with invalid name will be ignored instead of throwing CookieException.
It is useful when server sends cookie like:
```
Set-Cookie: CDN Bad Cookie Domain_Language=en-us; domain=baddomain.com; expires=Mon, 15-Sep-2069 12:24:30 GMT; path=/
```
Default this cookie on respons will cause exception and getting no response or other cookies. If IgnoreInvalidCookie is set to true bad cookie will be ignored (not added to CookieStorage) and you will get response and other cookies without errors.

Personally I found only one site with spaces in cookie's name but without these changes I couldn't get response.