### PR TITLE
add proxy template string for parsing "login:pass@ip:port" to ProxyCl…

### DIFF
--- a/Leaf.xNet/~Proxy/ProxyClient.cs
+++ b/Leaf.xNet/~Proxy/ProxyClient.cs
@@ -272,14 +272,57 @@ namespace Leaf.xNet
 
             int port = 0;
             string host = values[0];
+            string username = null;
+            string password = null;
 
-            if (values.Length >= 2)
+            if (!proxyAddress.Contains("@"))
             {
+                if (values.Length >= 2)
+                {
+                    #region Получение порта
+
+                    try
+                    {
+                        port = int.Parse(values[1]);
+                    }
+                    catch (Exception ex)
+                    {
+                        if (ex is FormatException || ex is OverflowException)
+                        {
+                            throw new FormatException(
+                                Resources.InvalidOperationException_ProxyClient_WrongPort, ex);
+                        }
+
+                        throw;
+                    }
+
+                    if (!ExceptionHelper.ValidateTcpPort(port))
+                    {
+                        throw new FormatException(
+                            Resources.InvalidOperationException_ProxyClient_WrongPort);
+                    }
+
+                    #endregion
+                }
+
+                if (values.Length >= 3)
+                    username = values[2];
+
+                if (values.Length >= 4)
+                    password = values[3]; 
+            }
+            else
+            {
+                //если строка была формата http://login:pass@ip:port
+                username = proxyAddress.Split('@')[0].Split(':')[0];
+                password = proxyAddress.Split('@')[0].Split(':')[1];
+                host = proxyAddress.Split('@')[1].Split(':')[0];
+
                 #region Получение порта
 
                 try
                 {
-                    port = int.Parse(values[1]);
+                    port = int.Parse(proxyAddress.Split('@')[1].Split(':')[1]);
                 }
                 catch (Exception ex)
                 {
@@ -299,16 +342,9 @@ namespace Leaf.xNet
                 }
 
                 #endregion
+
+
             }
-
-            string username = null;
-            string password = null;
-
-            if (values.Length >= 3)
-                username = values[2];
-
-            if (values.Length >= 4)
-                password = values[3];
 
             return ProxyHelper.CreateProxyClient(proxyType, host, port, username, password);
         }

--- a/README.md
+++ b/README.md
@@ -258,6 +258,15 @@ foreach (Cookie cookie in cookies) {
 ```
 
 ### Proxy
+Supporting proxy string templates:
+```
+[ip]:[port]    //e.g., http://127.0.0.1:80
+[ip]:[port]:[login]:[pass]     //e.g., http://127.0.0.1:80:login:pass
+[login]:[pass]@[ip]:[port]     //e.g., http://login:pass@127.0.0.1:80
+
+```
+
+
 Your proxy server:
 ```csharp
 // Type: HTTP / HTTPS 


### PR DESCRIPTION
Добавил парсинг строки прокси в формате "login:pass@ip:port" в методе ProxyClient.Parse(). А также в readme.md указал, в каком формате подавать прокси. Ибо сходу было не понятно)